### PR TITLE
Use "foreign" option for automake.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([wmpinboard], [1.0.1])
-AM_INIT_AUTOMAKE([-Wall silent-rules])
+AM_INIT_AUTOMAKE([-Wall silent-rules foreign])
 AM_CONFIG_HEADER(config.h)
 
 AC_PROG_CC


### PR DESCRIPTION
This prevents the following error during autoreconf:
     Makefile.am: error: required file './ChangeLog' not found
     autoreconf: automake failed with exit status: 1
