### PR TITLE
Check to see if HOME defined; exit with an error if it's not.

### DIFF
--- a/src/wmpinboard.c
+++ b/src/wmpinboard.c
@@ -177,6 +177,8 @@ notes_io(int save)
   s_block();
 
   s[sizeof(s)-1] = '\0';
+  if (!getenv("HOME"))
+    die("HOME environment variable undefined.");
   strncpy(s, getenv("HOME"), sizeof(s));
   if (sizeof(s)-strlen(s)-1 < strlen(rc_file_name)+strlen(ext))
     die("Buffer too small in notes_io().");


### PR DESCRIPTION
Previously, we would get a segfault.  This fixes Debian bug 716470 [1].

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=716470
